### PR TITLE
Use full ca chain + register an email address.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "**** install OpenSSL ****" && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
     \
     echo "**** install pip ****" && \
+    rm /usr/lib/python*/EXTERNALLY-MANAGED && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --no-cache --upgrade pip setuptools wheel && \

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ When this Docker image is updated and you want to start using it, or if you want
 ## Required Variables
 
  * DOMAIN_NAME
+ * EMAIL_ADDRESS
  * LINODE_CLI_TOKEN
  * NODEBALANCER_ID
  * CONFIG_ID

--- a/serve.sh
+++ b/serve.sh
@@ -10,6 +10,13 @@ then
     exit 1
 fi;
 
+# If we don't have an EMAIL_ADDRESS set, complain and exit
+if [ -z "$EMAIL_ADDRESS" ];
+then
+    echo "Error: EMAIL_ADDRESS variable not set."
+    exit 1
+fi;
+
 # If we don't have a LINODE_CLI_TOKEN set, complain and exit
 if [ -z "$LINODE_CLI_TOKEN" ];
 then
@@ -100,8 +107,11 @@ fi;
 # Start the web server in the background
 nginx
 
+# register email address
 $ACME --config-home /data \
     --register-account -m $EMAIL_ADDRESS --server zerossl
+
+# use zerossl by default
 $ACME --config-home /data \
     --set-default-ca  --server zerossl
 

--- a/serve.sh
+++ b/serve.sh
@@ -35,7 +35,7 @@ fi;
 
 export NODEBALANCER_LABEL=`linode-cli nodebalancers view $NODEBALANCER_ID --text --no-headers --format label`
 
-if [-z "$NODEBALANCER_LABEL" ];
+if [ -z "$NODEBALANCER_LABEL" ];
 then
     echo Bad NODEBALANCER_ID $NODEBALANCER_ID
     exit 1
@@ -107,7 +107,7 @@ $ACME --config-home /data \
       --reloadcmd "/install_cert.sh" \
       --pre-hook "rm $OK_FILE || true" \
       $NOTIFY_HOOK \
-      --cert-file /data/cert.pem \
+      --fullchain-file /data/cert.pem \
       --key-file /data/key.pem \
       --force
 

--- a/serve.sh
+++ b/serve.sh
@@ -100,6 +100,11 @@ fi;
 # Start the web server in the background
 nginx
 
+$ACME --config-home /data \
+    --register-account -m $EMAIL_ADDRESS --server zerossl
+$ACME --config-home /data \
+    --set-default-ca  --server zerossl
+
 # Run the cert for the given domain using nginx
 $ACME --config-home /data \
       --issue -d $DOMAIN_NAME \


### PR DESCRIPTION
This changes to use the full certificate chain, registers an email address with zerossl and fixes a couple typos.

This resolves issues #3 and #4 